### PR TITLE
Create github workflow for deploying a release to PyPI automatically

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -39,11 +39,25 @@ jobs:
           source env/bin/activate
           python -m build
         working-directory: sdk/python
+  
+      - name: List files in the dist folder
+        run: |
+          ls ${{ github.workspace }}/sdk/python/dist
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: sdk/python/dist
 
   pypi-publish:
     name: Upload Release to PyPI
     runs-on: ubuntu-latest
     needs: build
+
+    # TODO: This makes sense to do after this repo is more stable
+    # if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+
     environment:
       name: pypi
       url: https://pypi.org/p/freewayai
@@ -51,14 +65,15 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
       - name: Download distribution artifacts
         uses: actions/download-artifact@v4
         with:
-          name: dist
-          path: sdk/python/dist
+          name: python-dist
+          path: dist
 
-      - name: Publish package distributions to PyPI
+      - name: List files in the dist folder
+        run: |
+          ls ${{ github.workspace }}/dist
+
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,11 +1,8 @@
 name: Build and Publish Python Package to PyPI
 
-on: 
+on:
   push:
-    branches:
-      - main
-    paths:
-      - 'sdk/python/**'
+    tags: ['python-v[0-9].[0-9]+.[0-9]+']
 
 jobs:
   build:
@@ -54,9 +51,6 @@ jobs:
     name: Upload Release to PyPI
     runs-on: ubuntu-latest
     needs: build
-
-    # TODO: This makes sense to do after this repo is more stable
-    # if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
 
     environment:
       name: pypi

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,0 +1,64 @@
+name: Build and Publish Python Package to PyPI
+
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - 'sdk/python/**'
+
+jobs:
+  build:
+    name: Build with SetupTools
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11' 
+
+      - name: Create a Python virtual environment
+        run: |
+          python -m venv env
+          source env/bin/activate
+        working-directory: sdk/python
+
+      - name: Install build dependencies
+        run: |
+          source env/bin/activate
+          python -m pip install build
+        working-directory: sdk/python
+
+      - name: Build distributions into dist folder
+        shell: bash -l {0}
+        run: |
+          source env/bin/activate
+          python -m build
+        working-directory: sdk/python
+
+  pypi-publish:
+    name: Upload Release to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/freewayai
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: sdk/python/dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This uses the [Trusted Publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) workflow with PyPI where I've setup this repository and workflow as a trusted system to deploy on our behalf without having to manage tokens.

This is difficult to test, so it looks correct but won't know until we do it for the first time.