### PR TITLE
Added dynamic versioning to github release process

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -24,6 +24,9 @@ jobs:
           source env/bin/activate
         working-directory: sdk/python
 
+      - name: Extract version from tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/python-v}" >> $GITHUB_ENV
+
       - name: Install build dependencies
         run: |
           source env/bin/activate
@@ -36,9 +39,12 @@ jobs:
           source env/bin/activate
           python -m build
         working-directory: sdk/python
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ env.VERSION }}
   
       - name: List files in the dist folder
         run: |
+          echo "Release version number is: $VERSION"
           ls ${{ github.workspace }}/sdk/python/dist
 
       - name: Upload distribution artifacts

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "freewayai"
-version = "0.1.3"
 dependencies = ["tiktoken",]
 authors = [
   { name="Ben Parfitt", email="ben@diligently.ai" },
@@ -14,6 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dynamic=["version"]
 
 [project.urls]
 Homepage = "https://github.com/diligentlyai/freewayai"
@@ -21,10 +21,12 @@ Issues = "https://github.com/diligentlyai/freewayai/issues"
 
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["freewayai*"]
 exclude = ["freewayai.tests*"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
This should remove the need to manually increment the `version` field in the `pyproject.toml` file. The rest of the process is unchanged - tag a release in Github and it'll publish to PyPI.